### PR TITLE
Add obstack_printf function.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ## Makefile.am - procress this file with automake to produce Makefile.in
 lib_LTLIBRARIES = libobstack.la
-libobstack_la_SOURCES = obstack.c
+libobstack_la_SOURCES = obstack.c obstack_printf.c
 libobstack_la_HEADERS = obstack.h
 libobstack_ladir = $(includedir)
 ACLOCAL_AMFLAGS = -Im4

--- a/obstack.h
+++ b/obstack.h
@@ -235,6 +235,8 @@ int obstack_alignment_mask (struct obstack *obstack);
 int obstack_chunk_size (struct obstack *obstack);
 int obstack_memory_used (struct obstack *obstack);
 
+int obstack_printf(struct obstack *obstack, const char *__restrict fmt, ...);
+
 /* Error handler called when `obstack_chunk_alloc' failed to allocate
    more memory.  This can be set to a user defined function.  The
    default action is to print a message and abort.  */

--- a/obstack_printf.c
+++ b/obstack_printf.c
@@ -1,0 +1,18 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <strings.h>
+#include "obstack.h"
+
+int obstack_printf(struct obstack *obstack, const char *__restrict fmt, ...)
+{
+	char buf[1024];
+	va_list ap;
+	int len;
+
+	va_start(ap, fmt);
+	len = vsnprintf(buf, sizeof(buf), fmt, ap);
+	obstack_grow(obstack, buf, len);
+	va_end(ap);
+
+	return len;
+}


### PR DESCRIPTION
Most of the packages that I've found depend on musl-obstack also require the obstack_printf function, which is not yet provided by this package.

This implementation of obstack_printf is almost exactly the same as the version provided in the musl-obstack_printf.patch used in elfutils by you guys at voidlinux.
